### PR TITLE
data scaling was nans for some np versions, this is more robust

### DIFF
--- a/sensorium/datasets/mouse_video_loaders.py
+++ b/sensorium/datasets/mouse_video_loaders.py
@@ -107,10 +107,10 @@ def mouse_video_loader(
         if include_pupil_centers and include_pupil_centers_as_channels:
             more_transforms.append(AddPupilCenterAsChannels("videos"))
 
-        more_transforms.append(ToTensor(cuda))
-        more_transforms.insert(
-            0, ScaleInputs(scale=scale, in_name="videos", channel_axis=-1)
+        more_transforms.append(
+            ScaleInputs(scale=scale, in_name="videos", channel_axis=-1)
         )
+        more_transforms.append(ToTensor(cuda))
         if normalize:
             try:
                 more_transforms.insert(


### PR DESCRIPTION
Before scaling was applied before cutting videos to chunks of n frames. As it includes interpolation and original videos have nans, some version of the library resulted in nans being interpolated everywhere. So now scaling is the last data augmentation before putting data to tensors.